### PR TITLE
Bugfix/eugene/same origin iframe

### DIFF
--- a/chromeplay_contentscript.js
+++ b/chromeplay_contentscript.js
@@ -28,9 +28,12 @@ function checkForHtml5Video(document) {
 
 	var iframes = document.getElementsByTagName('iframe');
 	for (var i=0; i<iframes.length; i++) {
-		// Recursive search within iframe if it contains any video
-		ret = checkForHtml5Video(iframes[i].contentDocument);
-		if (ret.url) return ret;
+		// Search within same origin iframes because we can't access other domains
+		if (iframes[i].src.indexOf(window.document.domain) !== -1) {
+			// Recursive search within iframe if it contains any video
+			ret = checkForHtml5Video(iframes[i].contentDocument);
+			if (ret.url) return ret;
+		}
 	}
 
 	var noscripts = document.getElementsByTagName('noscript');

--- a/chromeplay_contentscript.js
+++ b/chromeplay_contentscript.js
@@ -14,7 +14,8 @@ function checkForHtml5Video(document) {
 	// Fallback to the window.document if no document is given
 	document = document || window.document;
 
-	if (document.getElementsByTagName('video').length > 0) {
+	var videos = document.getElementsByTagName('video');
+	if (videos.length > 0) {
 		var video = document.getElementsByTagName('video')[0];
 		ret.url = video.src;
 		ret.position = video.currentTime/video.duration;
@@ -24,21 +25,26 @@ function checkForHtml5Video(document) {
 		}
 		return ret;
 	}
-	else if (document.getElementsByTagName('iframe').length > 0 && document.getElementsByTagName('iframe')[0].contentDocument.getElementsByTagName('video').length > 0) {
+
+	var iframes = document.getElementsByTagName('iframe');
+	if (iframes.length > 0) {
 		// Recursive search within iframe if it contains any video
-		return checkForHtml5Video(document.getElementsByTagName('iframe')[0].contentDocument);
+		ret = checkForHtml5Video(iframes[0].contentDocument);
+		if (ret.url) return ret;
 	}
-	else {
-		var noscripts = document.getElementsByTagName('noscript');
-		for (var i=0; i<noscripts.length; i++) {
-		    var el = document.createElement("div");
-		    el.innerHTML = noscripts[i].innerHTML;
-			el.innerHTML = el.childNodes[0].nodeValue
-			if (el.getElementsByTagName('video').length > 0) {
-				return checkForHtml5Video(el);
-			}
+
+	var noscripts = document.getElementsByTagName('noscript');
+	for (var i=0; i<noscripts.length; i++) {
+	    var el = document.createElement("div");
+	    el.innerHTML = noscripts[i].innerHTML;
+		el.innerHTML = el.childNodes[0].nodeValue
+		if (el.getElementsByTagName('video').length > 0) {
+			ret = checkForHtml5Video(el);
+			if (ret.url) return ret;
 		}
 	}
+
+	return ret;
 }
 
 chrome.runtime.onMessage.addListener(

--- a/chromeplay_contentscript.js
+++ b/chromeplay_contentscript.js
@@ -71,7 +71,7 @@ function tryToEnableChromePlay(evt) {
 		function enableChromePlay() {
 			if (/^https?:\/\/(?:www\.)?youtube.com\/watch\?(?=[^?]*v=\w+)(?:[^\s?]+)?$/.test(document.URL)) {
 				chrome.extension.sendRequest({}, function(response) {}); // show the icon in omnibox
-			} else if (checkForHtml5Video()) { // we're having HTML5 video
+			} else if (checkForHtml5Video().url) { // we're having HTML5 video
 				chrome.extension.sendRequest({}, function(response) {}); // show the icon in omnibox
 		   	} else if (/vimeo.com/.test(document.URL)) {
 				// some magic to enable right-clicking on Vimeo videos

--- a/chromeplay_contentscript.js
+++ b/chromeplay_contentscript.js
@@ -15,21 +15,21 @@ function checkForHtml5Video(document) {
 	document = document || window.document;
 
 	var videos = document.getElementsByTagName('video');
-	if (videos.length > 0) {
-		var video = document.getElementsByTagName('video')[0];
+	for (var i=0; i<videos.length; i++) {
+		var video = videos[i];
 		ret.url = video.src;
 		ret.position = video.currentTime/video.duration;
 		if (!ret.url) {
 			var sources = document.getElementsByTagName('source');
 			ret.url = sources.length > 0 ? sources[0].src : null;
 		}
-		return ret;
+		if (ret.url) return ret;
 	}
 
 	var iframes = document.getElementsByTagName('iframe');
-	if (iframes.length > 0) {
+	for (var i=0; i<iframes.length; i++) {
 		// Recursive search within iframe if it contains any video
-		ret = checkForHtml5Video(iframes[0].contentDocument);
+		ret = checkForHtml5Video(iframes[i].contentDocument);
 		if (ret.url) return ret;
 	}
 

--- a/chromeplay_contentscript.js
+++ b/chromeplay_contentscript.js
@@ -17,12 +17,8 @@ function checkForHtml5Video(document) {
 	var videos = document.getElementsByTagName('video');
 	for (var i=0; i<videos.length; i++) {
 		var video = videos[i];
-		ret.url = video.src;
+		ret.url = video.currentSrc;
 		ret.position = video.currentTime/video.duration;
-		if (!ret.url) {
-			var sources = document.getElementsByTagName('source');
-			ret.url = sources.length > 0 ? sources[0].src : null;
-		}
 		if (ret.url) return ret;
 	}
 


### PR DESCRIPTION
Added support for multiple video and iframe tags. Now it lookups until find a video in all document or inside every iframe skipping iframes with different domain than origin (to prevent security error like `Uncaught SecurityError: Failed to read the 'contentDocument' property from 'HTMLIFrameElement': Blocked a frame with origin`).

Update:
added a fix to do not show icon when there is no video on the page
added improvement to use `video.currentSrc` instead of `video.src || video.source[0].src` check