### PR TITLE
Stops multiple "Airplay it!" options being created in the right-click context menu

### DIFF
--- a/background.js
+++ b/background.js
@@ -122,6 +122,7 @@ function parseWithRegExp(text, regex, processValue) { // regex needs 'g' flag
 }
 function parseFlashVariables(s) {return parseWithRegExp(s, /([^&=]*)=([^&]*)/g);}
 
+chrome.contextMenus.removeAll();
 chrome.contextMenus.create({
     "type":"normal", 
     "title":"AirPlay it!", 


### PR DESCRIPTION
The bug:
![chromeplay-multiple-options](https://cloud.githubusercontent.com/assets/564860/12071192/7c09b3bc-b0ea-11e5-8f0e-161ceb546bdc.gif)

* This happens because the background page is reloaded on save click
* Every time it is loaded it calls chrome.contextMenus.create(), which still holds any previously created context menus
* This just makes sure we have a clean slate before creating our context menus